### PR TITLE
Delete  `code` input parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,17 @@ Add the transformer:
 import { codeToHtml } from 'shiki/bundle/full'
 import { addCopyButton } from 'shiki-transformer-copy-button'
 
+// optionally add options
+const options = {
+  // delay time from "copied" state back to normal state
+  toggle: 2000,
+}
+
 export async function highlight(code, lang) {
   return await codeToHtml(code, {
     lang,
     transformers: [
-      addCopyButton(code)
+      addCopyButton(options)
     ]
   })
 }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the transformer:
 import { codeToHtml } from 'shiki/bundle/full'
 import { addCopyButton } from 'shiki-transformer-copy-button'
 
-// optionally add options
+// optional add options
 const options = {
   // delay time from "copied" state back to normal state
   toggle: 2000,

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the transformer:
 import { codeToHtml } from 'shiki/bundle/full'
 import { addCopyButton } from 'shiki-transformer-copy-button'
 
-// optional add options
+// optional
 const options = {
   // delay time from "copied" state back to normal state
   toggle: 2000,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import { h } from 'hastscript'
 
-export function addCopyButton(code, options = {}) {
+export function addCopyButton(options = {}) {
   const toggleMs = options.toggle || 3000
 
   return {
@@ -8,7 +8,7 @@ export function addCopyButton(code, options = {}) {
     pre(node) {
       const button = h('button', {
         class: 'copy',
-        "data-code": code,
+        "data-code": this.source,
         onclick: `
           navigator.clipboard.writeText(this.dataset.code);
           this.classList.add('copied');


### PR DESCRIPTION
According to the official documentation found at https://shiki.style/guide/transformers, the Shiki Transformer function yields an object and does not require any input arguments, as demonstrated in this example: https://shiki.style/packages/transformers#usage. 

![image](https://github.com/joshnuss/shiki-transformer-copy-button/assets/76400782/62f38dda-ddee-4b35-80ac-df7635de5c01)

In different use cases (like mine on rehype-pretty-codes), you have no way to get the code string except from `this.source`. Therefore, I adjusted the `"data-code"` value to `this.source`, eliminating the need for any input parameters in this function (except for optional toogleMs you provided).