### PR TITLE
readme: add a 'used by' section

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@main

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A [Shiki Transformer](https://shiki.style/guide/transformers) that adds a Copy button.
 
+## Used by
+
+<a href="https://github.com/joshnuss/shiki-transformer-copy-button/network/dependents">
+  <img src="https://dependents.info/joshnuss/shiki-transformer-copy-button/image.svg" />
+</a>
+
 ## Install
 
 Install the package:


### PR DESCRIPTION
Hi Joshua, thank you for this awesome plugin!

I've used it on my latest [open source](https://github.com/gouravkhunger/dependents.info) project [dependents.info](https://dependents.info) which aims to showcase other repositories that use a package. The copy button added to the code blocks by the plugin looks great on the website!

To give back to the project, I've created such a "Used by" image using my tool for you:

<img width="450" alt="image" src="https://github.com/user-attachments/assets/c630ad67-a1fa-46e9-a3d7-f07ee119cf4b" />
<br /><br />

With this PR, it would appear in the readme as a self updating (because of the gh action) image linked to the github's [network dependents](https://github.com/joshnuss/shiki-transformer-copy-button/network/dependents) page of this repository:

<img width="917" alt="image" src="https://github.com/user-attachments/assets/9deab8d2-c7a3-4d4e-a4db-bf388350b6cc" />
<br /><br />

Please feel free to close this PR if you don't want to have this!